### PR TITLE
adding setup.py which has been verified to work with ccp4

### DIFF
--- a/iris-validation/setup.py
+++ b/iris-validation/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as infile:
     
 setuptools.setup(
     name='iris-validation',
-    version='0.0.0',
+    version='0.0.1',
     author='William Rochira',
     author_email='william.rochira@hotmail.co.uk',
     description='A package for interactive all-in-one graphical validation of 3D protein model iterations',

--- a/iris-validation/setup.py
+++ b/iris-validation/setup.py
@@ -1,0 +1,26 @@
+import setuptools
+
+with open('README.md', 'r') as infile:
+    readme = infile.read()
+    
+setuptools.setup(
+    name='iris-validation',
+    version='0.0.0',
+    author='William Rochira',
+    author_email='william.rochira@hotmail.co.uk',
+    description='A package for interactive all-in-one graphical validation of 3D protein model iterations',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    packages=setuptools.find_packages(),
+    package_data={'iris_validation': [
+        'metrics/percentiles/data/*',
+        'metrics/rotamer/data/*',
+        'graphics/js/*',]},
+    include_package_data=True,
+    url='https://github.com/glycojones/iris-ccp',
+    classifiers=[
+        'Programming Language :: Python :: 3.7',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent' ],
+    python_requires='>=3'
+)


### PR DESCRIPTION
This is a `setup.py` file that is based on the previous version from the Python 2 version of `iris-validation` (https://github.com/wrochira/iris-validation/blob/master/setup.py)

I have verified that this works by:
- Running `sudo ccp4-python setup.py install` from the root of `iris-ccp`.
- Running `./BINARY.setup` and then `source bin/ccp4.setup-sh` from the root of the ccp4-8.0 release build. This is to recompile binary files.
- Executing the ccp4i2 graphical interface from the _development build_ (which is available from https://ccp4serv6.rc-harwell.ac.uk/anonscm/bzr/ccp4i2/). This has been modified such that we replace `wrappers/validate_protein` with the contents of [iris-ccp/validate_protein](https://github.com/glycojones/iris-ccp/tree/master/validate_protein/).
- Running Iris validation through the graphical interface: Validation and analysis > Multimetric model geometry validation, using example data.

CCP4 then generated an Iris report:
![Screenshot 2022-11-30 at 13 22 08](https://user-images.githubusercontent.com/23639373/204807275-8ae66193-6183-42f5-81fa-b1af57f7106b.png)

@wrochira Could you please check the arguments in this `setup.py`? The changes I've made are:
- `package_data` (to reflect the new code structure)
- `url`
- `classifiers` (I changed Python `2.7` to `3.7`) 
- `python_requires` from `>=2.7, <3` to `>=3`
Also, should the `version` be changed?