### PR TITLE
tortoize entries exist for non-amino acid chains

### DIFF
--- a/iris_validation/metrics/__init__.py
+++ b/iris_validation/metrics/__init__.py
@@ -53,6 +53,7 @@ def _get_molprobity_data(model_path, seq_nums, model_id=None, out_queue=None):
     except (ImportError, ModuleNotFoundError):
         print('WARNING: Failed to import MolProbity; continuing without MolProbity analyses')
         return
+
     try:
         cmdline = load_model_and_data(
             args=[ f'pdb.file_name="{model_path}"', 'quiet=True' ],

--- a/iris_validation/metrics/__init__.py
+++ b/iris_validation/metrics/__init__.py
@@ -53,7 +53,6 @@ def _get_molprobity_data(model_path, seq_nums, model_id=None, out_queue=None):
     except (ImportError, ModuleNotFoundError):
         print('WARNING: Failed to import MolProbity; continuing without MolProbity analyses')
         return
-
     try:
         cmdline = load_model_and_data(
             args=[ f'pdb.file_name="{model_path}"', 'quiet=True' ],
@@ -175,8 +174,8 @@ def _get_covariance_data(model_path,
     return covariance_data
 
 
-def _get_tortoize_data(model_path, model_id=None, out_queue=None):
-    rama_z_data = {}
+def _get_tortoize_data(model_path, seq_nums, model_id=None, out_queue=None):
+    rama_z_data = {chain_id: {} for chain_id in seq_nums.keys()}
     try:
         tortoize_process = subprocess.Popen(
             f'tortoize {model_path}',
@@ -190,8 +189,7 @@ def _get_tortoize_data(model_path, model_id=None, out_queue=None):
     tortoize_dict = json.loads(tortoize_output)
     residues = tortoize_dict["model"]["1"]["residues"]
     for res in residues:
-        chain_rama_z_data = rama_z_data.setdefault(res['pdb']['strandID'], {})
-        chain_rama_z_data[res['pdb']['seqNum']] = res['ramachandran']['z-score']
+        rama_z_data[res['pdb']['strandID']][res['pdb']['seqNum']] = res['ramachandran']['z-score']
 
     if out_queue is not None:
         out_queue.put(('rama_z', model_id, rama_z_data))
@@ -271,13 +269,13 @@ def metrics_model_series_from_files(model_paths,
         if calculate_rama_z:
             if multiprocessing:
                 p = Process(target=_get_tortoize_data,
-                            args=(model_path,),
+                            args=(model_path, seq_nums),
                             kwargs={ 'model_id': model_id,
                                      'out_queue': results_queue })
                 p.start()
                 num_queued += 1
             else:
-                rama_z_data = _get_tortoize_data(model_path)
+                rama_z_data = _get_tortoize_data(model_path, seq_nums)
 
         all_minimol_data.append(minimol)
         all_covariance_data.append(covariance_data)


### PR DESCRIPTION
We were getting errors for models that have some chains with no amino acids, such as 2z62. `_get_tortoize_data` does not generate entries for these chains, but `_get_molprobity_data` and `_get_covariance_data` do. This results in a `KeyError` in line 30 of `iris_validation/metrics/model.py`.

This PR fixes that bug by passing `seq_nums` to `_get_tortoize_data` and generating entries for all chains.