### PR TITLE
dealing with missing tortoize output

### DIFF
--- a/src/iris_validation/metrics/__init__.py
+++ b/src/iris_validation/metrics/__init__.py
@@ -178,17 +178,19 @@ def _get_covariance_data(model_path,
 
 def _get_tortoize_data(model_path, seq_nums, model_id=None, out_queue=None):
     rama_z_data = {chain_id: {} for chain_id in seq_nums.keys()}
+    tortoize_process = subprocess.Popen(
+        ['tortoize', str(model_path)],
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
     try:
-        tortoize_process = subprocess.Popen(
-            f'tortoize {model_path}',
-            shell=True,
-            stdout=subprocess.PIPE)
+        tortoize_output, tortoize_stderr = tortoize_process.communicate()
+        if tortoize_process.returncode != 0 or tortoize_stderr:
+            print('WARNING: Failed to run tortoize')
+        tortoize_dict = json.loads(tortoize_output)
     except Exception:
-        print('WARNING: Failed to run tortoize')
+        print('WARNING: Failed to read tortoize output')
         return
-
-    tortoize_output = tortoize_process.communicate()[0]
-    tortoize_dict = json.loads(tortoize_output)
 
     residues = tortoize_dict["model"]["1"]["residues"]
     for res in residues:


### PR DESCRIPTION
When tortoize crashed, Iris crashes as well. I am proposing these changes to deal better with a tortioize crash. Please check and test it.